### PR TITLE
fix skillapi bug and ui

### DIFF
--- a/src/main/kotlin/ink/ptms/chemdah/core/quest/objective/skillapi/SSkillUpgrade.kt
+++ b/src/main/kotlin/ink/ptms/chemdah/core/quest/objective/skillapi/SSkillUpgrade.kt
@@ -26,10 +26,10 @@ object SSkillUpgrade : ObjectiveCountableI<PlayerSkillUpgradeEvent>() {
             data.toPosition().inside(it.playerData.player.location)
         }
         addSimpleCondition("skill") { data, it ->
-            data.toString().equals(it.upgradedSkill.status.name, true)
+            data.toString().equals(it.upgradedSkill.data.name, true)
         }
         addConditionVariable("skill") {
-            it.upgradedSkill.status.name
+            it.upgradedSkill.data.name
         }
     }
 }

--- a/src/main/kotlin/ink/ptms/chemdah/module/ui/UI.kt
+++ b/src/main/kotlin/ink/ptms/chemdah/module/ui/UI.kt
@@ -90,7 +90,8 @@ class UI(val config: ConfigurationSection) {
                         // 任务可以接受
                         if (cond.type == AcceptResult.Type.SUCCESSFUL) {
                             // 任务允许显示可接受状态
-                            if (ui?.visibleStart == true) {
+                            // 且任务的前置任务已被完成 才显示在UI
+                            if (ui?.visibleStart == true && quest.isQuestDependCompleted(playerProfile.player)) {
                                 collect.add(UITemplate(quest, ItemType.QUEST_CAN_START))
                             }
                         } else {


### PR DESCRIPTION
修复了skillapi触发器中skillapi skill upgrade无法识别的问题
UI界面显示任务部分：
当该任务有前置任务且前置未被完成时，UI中将不会显示该任务