### PR TITLE
为SkillAPI Kether语句提供name、group获取

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,6 +82,8 @@ dependencies {
     compileOnly("public:CustomGo:1.0.0")
     compileOnly("public:Skript:1.0.0")
     compileOnly("public:SkillAPI:s1.98")
+    //compileOnly("com.promcteam:proskillapi:1.1.8")
+    //compileOnly("com.promcteam:promccore:1.0.4")
     compileOnly("public:mcMMO:1.0.0")
     compileOnly("public:MMOLib:1.0.0")
     compileOnly("public:MMOCore:1.10.2")

--- a/src/main/kotlin/ink/ptms/chemdah/module/kether/compat/ActionSkillAPI.kt
+++ b/src/main/kotlin/ink/ptms/chemdah/module/kether/compat/ActionSkillAPI.kt
@@ -1,5 +1,6 @@
 package ink.ptms.chemdah.module.kether.compat
 
+
 import com.sucy.skill.SkillAPI
 import com.sucy.skill.api.player.PlayerData
 import ink.ptms.chemdah.util.getBukkitPlayer
@@ -35,9 +36,11 @@ class ActionSkillAPI {
         fun parser() = scriptParser {
             when (it.expects("class", "skills", "attribute", "level", "exp", "experience", "mana", "cast")) {
                 "class" -> {
-                    Base(when (it.expects("main", "size")) {
+                    Base(when (it.expects("main", "size", "name", "group")) {
                         "main" -> { data -> data.mainClass }
                         "size" -> { data -> data.classes.size }
+                        "name" -> { data -> data.mainClass.data.name }
+                        "group" -> { data -> data.mainClass.data.group }
                         else -> error("out of case")
                     })
                 }


### PR DESCRIPTION
Skillapi语句新增name、group以获取职业名、组名（种族、阵营）
原先的main获取的更类似于类名，且每个玩家都有对应的数据，难以通过if直接调用为职业/阵营判据