### PR TITLE
fix Asynchronous effect add

### DIFF
--- a/src/main/kotlin/ink/ptms/chemdah/core/conversation/ConversationManager.kt
+++ b/src/main/kotlin/ink/ptms/chemdah/core/conversation/ConversationManager.kt
@@ -20,6 +20,7 @@ import taboolib.common.platform.event.EventPriority
 import taboolib.common.platform.event.OptionalEvent
 import taboolib.common.platform.event.SubscribeEvent
 import taboolib.common.platform.function.submit
+import taboolib.common.util.sync
 import taboolib.module.configuration.Config
 import taboolib.module.configuration.Configuration
 import taboolib.platform.util.onlinePlayers
@@ -119,11 +120,13 @@ object ConversationManager {
     @SubscribeEvent
     private fun onClosed(e: ConversationEvents.Closed) {
         if (!e.session.conversation.hasFlag("NO_EFFECT")) {
-            effectFreeze.forEach { e.session.player.removePotionEffect(it.key) }
-            effects.remove(e.session.player.name)?.forEach { e.session.player.addPotionEffect(it) }
-            // 视觉效果
-            if (!e.session.player.hasPotionEffect(PotionEffectType.BLINDNESS)) {
-                e.session.player.addPotionEffect(PotionEffect(PotionEffectType.BLINDNESS, 20, 0))
+            sync {
+                effectFreeze.forEach { e.session.player.removePotionEffect(it.key) }
+                effects.remove(e.session.player.name)?.forEach { e.session.player.addPotionEffect(it) }
+                // 视觉效果
+                if (!e.session.player.hasPotionEffect(PotionEffectType.BLINDNESS)) {
+                    e.session.player.addPotionEffect(PotionEffect(PotionEffectType.BLINDNESS, 20, 0))
+                }
             }
         }
     }


### PR DESCRIPTION
fix Asynchronous effect add
` Could not pass event Closed to Chemdah v0.3.25
java.lang.IllegalStateException: Asynchronous effect add!
        at org.spigotmc.AsyncCatcher.catchOp(AsyncCatcher.java:15) ~[paper.jar:git-Paper-1620]
        at net.minecraft.server.v1_12_R1.EntityLiving.addEffect(EntityLiving.java:690) ~[paper.jar:git-Paper-1620]
        at org.bukkit.craftbukkit.v1_12_R1.entity.CraftLivingEntity.addPotionEffect(CraftLivingEntity.java:276) ~[paper.jar:git-Paper-1620]
        at org.bukkit.craftbukkit.v1_12_R1.entity.CraftLivingEntity.addPotionEffect(CraftLivingEntity.java:266) ~[paper.jar:git-Paper-1620]
        at ink.ptms.chemdah.core.conversation.ConversationManager.onClosed(ConversationManager.kt:126) ~[?:?]
        at java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:710) ~[?:?]
        at ink.ptms.chemdah.taboolib.library.reflex.JavaClassMethod.invoke(JavaClassMethod.kt:31) ~[?:?]
        at ink.ptms.chemdah.taboolib.common.platform.event.EventBus.invoke(EventBus.kt:132) ~[?:?]
        at ink.ptms.chemdah.taboolib.common.platform.event.EventBus.invoke$default(EventBus.kt:130) ~[?:?]
        at ink.ptms.chemdah.taboolib.common.platform.event.EventBus$registerBukkit$2.invoke(EventBus.kt:77) ~[?:?]
        at ink.ptms.chemdah.taboolib.common.platform.event.EventBus$registerBukkit$2.invoke(EventBus.kt:76) ~[?:?]
        at ink.ptms.chemdah.taboolib.common.platform.function.ListenerKt$registerBukkitListener$1.invoke(Listener.kt:39) ~[?:?]
        at ink.ptms.chemdah.taboolib.common.platform.function.ListenerKt$registerBukkitListener$1.invoke(Listener.kt:39) ~[?:?]
        at ink.ptms.chemdah.taboolib.platform.BukkitListener$registerListener$listener$1.invoke(BukkitListener.kt:35) ~[?:?]
        at ink.ptms.chemdah.taboolib.platform.BukkitListener$registerListener$listener$1.invoke(BukkitListener.kt:35) ~[?:?]
        at ink.ptms.chemdah.taboolib.platform.BukkitListener$BukkitListener.execute(BukkitListener.kt:72) ~[?:?]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:74) ~[paper.jar:git-Paper-1620]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:62) ~[paper.jar:git-Paper-1620]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:513) ~[paper.jar:git-Paper-1620]
        at ink.ptms.chemdah.taboolib.platform.type.BukkitProxyEvent.call(BukkitProxyEvent.kt:40) ~[?:?]
        at ink.ptms.chemdah.core.conversation.Session.close$lambda-1$lambda-0(Session.kt:89) ~[?:?]
        at java.util.concurrent.CompletableFuture.uniApplyNow(CompletableFuture.java:680) ~[?:?]
        at java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:658) ~[?:?]
        at java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:2094) ~[?:?]
        at ink.ptms.chemdah.core.conversation.Session.close$lambda-1(Session.kt:84) ~[?:?]
        at java.util.concurrent.CompletableFuture.uniApplyNow(CompletableFuture.java:680) ~[?:?]
        at java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:658) ~[?:?]
        at java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:2094) ~[?:?]
        at ink.ptms.chemdah.core.conversation.Session.close(Session.kt:78) ~[?:?]
        at ink.ptms.chemdah.core.conversation.Session.close$default(Session.kt:72) ~[?:?]
        at ink.ptms.chemdah.module.kether.conversation.ConversationClose.run(ConversationClose.kt:20) ~[?:?]
        at ink.ptms.chemdah.taboolib.module.kether.ScriptAction.process(ScriptAction.kt:16) ~[?:?]
        at ink.ptms.chemdah.taboolib.library.kether.ParsedAction.process(ParsedAction.java:25) ~[?:?]
        at ink.ptms.chemdah.taboolib.library.kether.AbstractQuestContext$SimpleNamedFrame.process(AbstractQuestContext.java:256) ~[?:?]
        at ink.ptms.chemdah.taboolib.library.kether.AbstractQuestContext$SimpleNamedFrame.lambda$process$0(AbstractQuestContext.java:258) ~[?:?]
        at java.util.concurrent.CompletableFuture$UniRun.tryFire(CompletableFuture.java:783) ~[?:?]
        at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506) ~[?:?]
        at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2073) ~[?:?]
        at ink.ptms.chemdah.core.conversation.Conversation$open$2$1.invoke$lambda-5$lambda-4$lambda-3$lambda-2(Conversation.kt:153) ~[?:?]
        at java.util.concurrent.CompletableFuture.uniAcceptNow(CompletableFuture.java:753) ~[?:?]
        at java.util.concurrent.CompletableFuture.uniAcceptStage(CompletableFuture.java:731) ~[?:?]
        at java.util.concurrent.CompletableFuture.thenAccept(CompletableFuture.java:2108) ~[?:?]
        at ink.ptms.chemdah.core.conversation.Conversation$open$2$1.invoke$lambda-5$lambda-4$lambda-3(Conversation.kt:152) ~[?:?]
        at java.util.concurrent.CompletableFuture$UniAccept.tryFire(CompletableFuture.java:714) ~[?:?]
        at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506) ~[?:?]
        at java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1742) ~[?:?]
        at java.util.concurrent.CompletableFuture$AsyncRun.exec(CompletableFuture.java:1728) ~[?:?]
        at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290) ~[?:?]
        at java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020) ~[?:?]
        at java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656) ~[?:?]
        at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594) ~[?:?]
        at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183) ~[?:?]`